### PR TITLE
Fix #10 : The suggestion thrown an exception if there is no arg

### DIFF
--- a/src/fr/devsylone/fallenkingdom/commands/rules/rulescommands/AllowBlock.java
+++ b/src/fr/devsylone/fallenkingdom/commands/rules/rulescommands/AllowBlock.java
@@ -14,6 +14,9 @@ import fr.devsylone.fkpi.rules.AllowedBlocks;
 
 public class AllowBlock extends FkRuleCommand
 {
+	// Si ENDER dans le nom, même si c'est un mauvais material, prevenir que les yeux c'est une state du ENDER_PORTAL_FRAME
+	private static final String ENDER_EYE_MSG =  "§a[Note] Si vous souhaitez autoriser les joueurs à compléter les portails de l'end avec des yeux, utilisez §e/fk rules allowblock ENDER_PORTAL_FRAME";
+
 	public AllowBlock()
 	{
 		super("allowBlock", "[block] OU /fk rules allowBlock (prendra l'item dans votre main)", 0, "Permet de pouvoir poser un bloc en dehors de sa base.");
@@ -22,26 +25,19 @@ public class AllowBlock extends FkRuleCommand
 	public void execute(Player sender, FkPlayer fkp, String[] args)
 	{
 		Player p = org.bukkit.Bukkit.getPlayer(sender.getName());
-
-
-
-		// Si ENDER dans le nom, même si c'est un mauvais material, prevenir que les yeux c'est une state du ENDER_PORTAL_FRAME
-		if(args[0].contains("ender"))
-			p.sendMessage(ChatUtils.PREFIX + "§a[Note] Si vous souhaitez autoriser les joueurs à compléter les portails de l'end avec des yeux, utilisez §e/fk rules allowblock ENDER_PORTAL_FRAME");
 		
 		Material m = null;
-		try
-		{
+		if(args.length > 0) {
 			String block = args[0];
 			m = Material.matchMaterial(block);
+			makeSuggestionIf(block, "ender", ENDER_EYE_MSG, p);
 			if(m == null)
 				throw new FkLightException(block + " n'est pas un bloc ! ");
-		}catch(ArrayIndexOutOfBoundsException e)
-		{
+		} else {
 			if(p == null || p.getItemInHand().getType().equals(Material.AIR))
 				throw new FkLightException(usage);
-
 			m = p.getItemInHand().getType();
+			makeSuggestionIf(m.name(), "ender", ENDER_EYE_MSG, p);
 		}
 		AllowedBlocks rule = (AllowedBlocks) Fk.getInstance().getFkPI().getRulesManager().getRuleByName("AllowedBlocks");
 
@@ -51,5 +47,11 @@ public class AllowBlock extends FkRuleCommand
 		
 		list.add(m.name());
 		broadcast("Le bloc", m.toString(), "peut maintenant être posé en dehors de sa base ! ");
+	}
+
+	public void makeSuggestionIf(String haystack, String needle, String message, Player player)
+	{
+		if (haystack.toLowerCase().contains(needle.toLowerCase()))
+			player.sendMessage(ChatUtils.PREFIX + message);
 	}
 }


### PR DESCRIPTION
Bonjour,
Cette PR corrige l'issue #10. En effet, lorsque la commande `/fk rules allowBlock` est utilisée, une exception de type ArrayIndexOutOfBoundsException est systématiquement levée.
La condition qui vérifiait si le nom contient "ender" ne s'assurait pas au préalable de la longueur du tableau d'arguments.